### PR TITLE
Allow remote Meteor connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file. [*File syntax*](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## VNEXT
+### New features
+
+- Allow remote Meteor connections ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#33](https://github.com/apollostack/graphql-tools/pull/33)).
+
 ## [0.1.0] - 2016-08-05
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## VNEXT
 ### New features
 
-- Allow remote Meteor connections ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#33](https://github.com/apollostack/graphql-tools/pull/33)).
+- Allow remote Meteor connections ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#33](https://github.com/apollostack/meteor-integration/pull/33)).
 
 ## [0.1.0] - 2016-08-05
 ### Updated


### PR DESCRIPTION
This changes allows us to use remote Meteor connections to configure Apollo.

It also allows to pass a custom function to get the user stored token.
