### PR TITLE
Configure a batching interface through the options

### DIFF
--- a/check-npm.js
+++ b/check-npm.js
@@ -3,7 +3,7 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 
 if (Meteor.isClient) {
   checkNpmVersions({
-    'apollo-client': '^0.5.0',
+    'apollo-client': '^0.7.0',
   }, 'apollo');
 } else {
   checkNpmVersions({

--- a/main-client.js
+++ b/main-client.js
@@ -35,7 +35,7 @@ export const createMeteorNetworkInterface = (givenConfig) => {
   }
 
   // if 'fetch' has been configured to be called with specific opts, add it to the options
-  if(!_.isEmpty(opts)) {
+  if(!_.isEmpty(config.opts)) {
     interfaceOptions.opts = config.opts;  
   }
   


### PR DESCRIPTION
Hey @lorensr!

PR for issue #38, as the way of defining query batching for the Apollo Client changed. 

I updated the version of `apollo-client` in the NPM check so that it takes care of recent modifications [like this one](https://github.com/apollostack/apollo-client/blob/master/CHANGELOG.md#055).

To define a `BatchedNetworkInterface`, we could do now something like : 

```js
import ApolloClient from 'apollo-client';
import { meteorClientConfig } from 'meteor/apollo';

const client = new ApolloClient(meteorClientConfig({
  batchingInterface: true,
  batchInterval: 20, // optional, default to 10
}));
```

I also added some comments on the default config to be more explicit, and seized the opportunity to pass the `opts` to the `networkInterface`, so we can also do something like: 

```js
import ApolloClient from 'apollo-client';
import { meteorClientConfig } from 'meteor/apollo';

const client = new ApolloClient(meteorClientConfig({
  opts: {
    credentials: 'same-origin', // pass the cookies with the request
  }
}));
```

What do you think? Should I do a PR on the docs too?