### PR TITLE
Allow to extend Apollo Client and network interface config, more tests (client config, query deduplication)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. [*File synt
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## vNEXT
+### Added
+
+-  Add query deduplication option for `meteorClientConfig` [#70](https://github.com/apollographql/meteor-integration/pull/70)
 
 ## [0.3.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## vNEXT
 ### Added
 
--  Add query deduplication option for `meteorClientConfig` [#70](https://github.com/apollographql/meteor-integration/pull/70)
+-  Make it possible to extend the default Apollo Client & network interface configuration objects with any Apollo Client & interface options (+ some tests) [#70](https://github.com/apollographql/meteor-integration/pull/70)
+
+### Updated
+
+- Don't force `meteor/apollo` to update their NPM dependencies on Graphql-related packages, clean-up the User Accounts middleware [#74](https://github.com/apollographql/meteor-integration/pull/74)
 
 ## [0.3.1]
 ### Fixed

--- a/main-client.js
+++ b/main-client.js
@@ -13,7 +13,7 @@ const defaultNetworkInterfaceConfig = {
   batchInterval: 10, // default batch interval
 };
 
-export const createMeteorNetworkInterface = (givenConfig) => {
+export const createMeteorNetworkInterface = (givenConfig = {}) => {
   const config = _.extend(defaultNetworkInterfaceConfig, givenConfig);
 
   // absoluteUrl adds a '/', so let's remove it first
@@ -80,8 +80,12 @@ export const createMeteorNetworkInterface = (givenConfig) => {
   return networkInterface;
 };
 
-export const meteorClientConfig = (networkInterfaceConfig) => {
+export const meteorClientConfig = (globalConfig = {}) => {
+  // destructure general apollo client configuration from network interface configuration
+  const { queryDeduplication = false, ...networkInterfaceConfig } = globalConfig;
+  
   return {
+    queryDeduplication,
     ssrMode: Meteor.isServer,
     networkInterface: createMeteorNetworkInterface(networkInterfaceConfig),
 

--- a/main-client.js
+++ b/main-client.js
@@ -13,8 +13,13 @@ const defaultNetworkInterfaceConfig = {
   batchInterval: 10, // default batch interval
 };
 
-export const createMeteorNetworkInterface = (givenConfig = {}) => {
-  const config = _.extend(defaultNetworkInterfaceConfig, givenConfig);
+export const createMeteorNetworkInterface = (customNetworkInterfaceConfig = {}) => {
+  // create a new config object based on the default network interface config defined above
+  // and the custom network interface config passed to this function
+  const config = {
+    ...defaultNetworkInterfaceConfig, 
+    ...customNetworkInterfaceConfig,
+  };
 
   // absoluteUrl adds a '/', so let's remove it first
   let path = config.path;
@@ -80,23 +85,23 @@ export const createMeteorNetworkInterface = (givenConfig = {}) => {
   return networkInterface;
 };
 
-export const meteorClientConfig = (globalConfig = {}) => {
-  // destructure general apollo client configuration from network interface configuration
-  const { queryDeduplication = false, ...networkInterfaceConfig } = globalConfig;
-  
-  return {
-    queryDeduplication,
-    ssrMode: Meteor.isServer,
-    networkInterface: createMeteorNetworkInterface(networkInterfaceConfig),
-
-    // Default to using Mongo _id, must use _id for queries.
-    dataIdFromObject: (result) => {
-      if (result._id && result.__typename) {
-        const dataId = result.__typename + result._id;
-        return dataId;
-      }
-
-      return null;
-    },
-  };
+// default Apollo Client config object
+const defaultClientConfig = {
+  networkInterface: createMeteorNetworkInterface(),
+  ssrMode: Meteor.isServer,
+  dataIdFromObject: (result) => {
+    if (result._id && result.__typename) {
+      // Store normalization with typename + Meteor's Mongo _id
+      const dataId = result.__typename + result._id;
+      return dataId;
+    }
+    return null;
+  },
 };
+
+// create a new client config object based on the default Apollo Client config defined above
+// and the client config passed to this function 
+export const meteorClientConfig = (customClientConfig = {}) => ({
+  ...defaultClientConfig,
+  ...customClientConfig,
+});

--- a/package.js
+++ b/package.js
@@ -21,6 +21,7 @@ Package.onTest(function(api) {
            'practicalmeteor:mocha',
            'practicalmeteor:chai',
            'http',
+           'random',
            'apollo']);
 
   api.mainModule('tests/client.js', 'client');

--- a/tests/client.js
+++ b/tests/client.js
@@ -1,6 +1,7 @@
 import { assert } from 'meteor/practicalmeteor:chai';
+import { createMeteorNetworkInterface, meteorClientConfig } from 'meteor/apollo';
 
-import { createMeteorNetworkInterface } from 'meteor/apollo';
+import ApolloClient from 'apollo-client';
 import gql from 'graphql-tag';
 import { print } from 'graphql-tag/printer';
 import 'whatwg-fetch';
@@ -42,6 +43,46 @@ describe('Network interface', function() {
   
   it('should create a network interface', function() {
     assert.ok(createMeteorNetworkInterface({batchingInterface: false}));
+  });
+  
+});
+
+describe('Query deduplication', () => {
+  
+  const randomQuery = gql`
+    query {
+      randomString
+    }`;
+  
+  it('does not deduplicate queries by default', () => {
+    
+    // we have two responses for identical queries, but only the first should be requested.
+    // the second one should never make it through to the network interface.
+    const client = new ApolloClient(meteorClientConfig());
+
+    const q1 = client.query({ query: randomQuery });
+    const q2 = client.query({ query: randomQuery });
+
+    // if deduplication happened, result2.data will equal data.
+    return Promise.all([q1, q2]).then(([result1, result2]) => {
+      expect(result1.data).to.not.equal(result2.data);
+    });
+  });
+
+  it('deduplicates queries if the option is set', () => {
+
+    // we have two responses for identical queries, but only the first should be requested.
+    // the second one should never make it through to the network interface.
+    
+    const client = new ApolloClient(meteorClientConfig({queryDeduplication: true}));
+
+    const q1 = client.query({ query: randomQuery });
+    const q2 = client.query({ query: randomQuery });
+
+    // if deduplication didn't happen, result.data will equal data2.
+    return Promise.all([q1, q2]).then(([result1, result2]) => {
+      assert.deepEqual(result1.data, result2.data);
+    });
   });
   
 });

--- a/tests/server.js
+++ b/tests/server.js
@@ -47,7 +47,7 @@ describe('Graphql Server', function() {
       data: { query: '{ test(who: "World") }' }
     });
     
-    expect(queryResult).to.deep.equal({
+    assert.deepEqual(queryResult, {
       data: {
         test: 'Hello World'
       }

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,5 +1,6 @@
 import { assert } from 'meteor/practicalmeteor:chai';
 import { HTTP } from 'meteor/http';
+import { Random } from 'meteor/random';
 import { createApolloServer } from 'meteor/apollo';
 
 import { makeExecutableSchema } from 'graphql-tools';
@@ -12,6 +13,7 @@ describe('Graphql Server', function() {
       test(who: String): String
       author: Author
       person: Person
+      randomString: String
     }
     
     type Author {
@@ -29,7 +31,8 @@ describe('Graphql Server', function() {
       test: (root, { who }) => `Hello ${who}`, 
       author: __ => ({firstName: 'John', lastName: 'Smith'}),
       person: __ => ({name: 'John Smith'}),
-    } 
+      randomString: __ => Random.id(),
+    }, 
   };
   
   const schema = makeExecutableSchema({ typeDefs, resolvers, });


### PR DESCRIPTION
It's me again! 😄  

[Query deduplication](http://dev.apollodata.com/core/network.html#query-deduplication) can be pretty handy, I've thought it would be a good thing to offer Meteor developers using this package to set deduplication option up.

I believe this open the door to a new way to configure the Apollo Client via the Meteor `apollo` package, [given all the params an Apollo Client instance accepts](https://github.com/apollographql/apollo-client/blob/master/src/ApolloClient.ts#L104-L134). 

I see especially two types of config:
* Network interface config
* And the rest 😄 (we are already using `ssrMode`, `queryDeduplication` & `dataObjectFromId`)

We could have two types of default config, the `defaultNetworkInterfaceConfig` and `defaultClientOptions`? Or maybe everything in the same object? 

I don't know what would be the easiest and the most useful for Meteor folks. What do you think?