### PR TITLE
Rewrite login token check client-side, add tests on Users Accounts, update dependencies

### DIFF
--- a/check-npm.js
+++ b/check-npm.js
@@ -3,7 +3,7 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 
 if (Meteor.isClient) {
   checkNpmVersions({
-    'apollo-client': '^0.8.0',
+    'apollo-client': '^0.7.0 || ^0.8.0',
     'isomorphic-fetch': '^2.2.1',
   }, 'apollo');
 } else {
@@ -11,7 +11,7 @@ if (Meteor.isClient) {
     'graphql-server-express': '^0.5.0',
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "graphql": "^0.9.0",
-    "graphql-tools": "^0.10.0",
+    "graphql": "^0.7.0 || ^0.8.0 || ^0.9.0",
+    "graphql-tools": "^0.9.0 || ^0.10.0",
   }, 'apollo');
 }

--- a/check-npm.js
+++ b/check-npm.js
@@ -3,14 +3,15 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 
 if (Meteor.isClient) {
   checkNpmVersions({
-    'apollo-client': '^0.7.0 || ^0.8.0',
+    'apollo-client': '^0.8.0',
+    'isomorphic-fetch': '^2.2.1',
   }, 'apollo');
 } else {
   checkNpmVersions({
     'graphql-server-express': '^0.5.0',
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "graphql": "^0.7.0 || ^0.8.0",
-    "graphql-tools": "^0.9.0",
+    "graphql": "^0.9.0",
+    "graphql-tools": "^0.10.0",
   }, 'apollo');
 }

--- a/check-npm.js
+++ b/check-npm.js
@@ -8,7 +8,7 @@ if (Meteor.isClient) {
   }, 'apollo');
 } else {
   checkNpmVersions({
-    'graphql-server-express': '^0.5.0',
+    'graphql-server-express': '^0.5.0 || ^0.6.0',
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "graphql": "^0.7.0 || ^0.8.0 || ^0.9.0",

--- a/main-client.js
+++ b/main-client.js
@@ -1,6 +1,7 @@
 import './check-npm.js';
 
 import { createNetworkInterface, createBatchingNetworkInterface } from 'apollo-client';
+import 'isomorphic-fetch';
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';

--- a/main-client.js
+++ b/main-client.js
@@ -74,7 +74,7 @@ export const createMeteorNetworkInterface = (givenConfig) => {
             request.options.headers = new Headers();
           }
 
-          request.options.headers.Authorization = currentUserToken;
+          request.options.headers['meteor-login-token'] = currentUserToken;
           
           next();
         },

--- a/main-client.js
+++ b/main-client.js
@@ -43,38 +43,42 @@ export const createMeteorNetworkInterface = (givenConfig) => {
   const networkInterface = interfaceToUse(interfaceOptions);
 
   if (config.useMeteorAccounts) {
-    networkInterface.use([{
-      applyMiddleware(request, next) {
+    // possible cookie login token created by meteorhacks:fast-render 
+    // and passed to the Apollo Client during server-side rendering
+    const { loginToken } = config;
 
-        // cookie login token created by meteorhacks:fast-render and caught during server-side rendering by rr:react-router-ssr
-        const { loginToken: cookieLoginToken } = config;
-        // Meteor accounts-base login token stored in local storage, only exists client-side
-        const localStorageLoginToken = Meteor.isClient && Accounts._storedLoginToken();
+    if (Meteor.isClient && loginToken) {
+      // note: as it's not possible to stop a request,
+      // should this be handled somehow server-side?
+      console.error('[Meteor Apollo Integration] The current user is not handled with your GraphQL requests: you are trying to pass a login token to an Apollo Client instance defined client-side. This is only allowed during server-side rendering, please check your implementation.');
+    } else {
+      networkInterface.use([{
+        applyMiddleware(request, next) {
+          
+          // Meteor accounts-base login token stored in local storage,
+          // only exists client-side as of Meteor 1.4, will exist with Meteor 1.5
+          const localStorageLoginToken = Meteor.isClient && Accounts._storedLoginToken();
+          
+          // define a current user token if existing 
+          // ex: passed during server-side rendering or grabbed from local storage
+          let currentUserToken = localStorageLoginToken || loginToken;
+          
+          if (!currentUserToken) {
+            next();
+            return;
+          }
+          
+          if (!request.options.headers) {
+            // Create the header object if needed.
+            request.options.headers = new Headers();
+          }
 
-        // on initial load, prefer to use the token grabbed server-side if existing
-        let currentUserToken = cookieLoginToken || localStorageLoginToken;
-
-        // ...a login token has been passed to the config, however the "true" one is different ⚠️
-        // https://github.com/apollostack/meteor-integration/pull/57/files#r96745502
-        if (Meteor.isClient && cookieLoginToken && cookieLoginToken !== localStorageLoginToken) {
-          // be sure to pass the right token to the request!
-          currentUserToken = localStorageLoginToken;
-        }
-
-        if (!currentUserToken) {
+          request.options.headers.Authorization = currentUserToken;
+          
           next();
-          return;
-        }
-
-        if (!request.options.headers) {
-          request.options.headers = new Headers();
-        }
-
-        request.options.headers.Authorization = currentUserToken;
-
-        next();
-      },
-    }]);
+        },
+      }]);
+    }
   }
 
   return networkInterface;

--- a/main-server.js
+++ b/main-server.js
@@ -18,7 +18,7 @@ const defaultConfig = {
   graphiql : Meteor.isDevelopment,
   graphiqlPath : '/graphiql',
   graphiqlOptions : {
-    passHeader : "'Authorization': localStorage['Meteor.loginToken']"
+    passHeader : "'meteor-login-token': localStorage['Meteor.loginToken']"
   },
   configServer: (graphQLServer) => {},
 };
@@ -65,8 +65,8 @@ export const createApolloServer = (givenOptions = {}, givenConfig = {}) => {
     }
 
     // Get the token from the header
-    if (req.headers.authorization) {
-      const token = req.headers.authorization;
+    if (req.headers['meteor-login-token']) {
+      const token = req.headers['meteor-login-token'];
       check(token, String);
       const hashedToken = Accounts._hashLoginToken(token);
 

--- a/package.js
+++ b/package.js
@@ -21,6 +21,7 @@ Package.onTest(function(api) {
            'practicalmeteor:mocha',
            'practicalmeteor:chai',
            'http',
+           'accounts-base',
            'apollo']);
 
   api.mainModule('tests/client.js', 'client');

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   },
   "homepage": "https://github.com/apollostack/meteor-integration#readme",
   "dependencies": {
-    "apollo-client": "^0.7.3",
-    "body-parser": "^1.15.2",
+    "apollo-client": "^0.8.7",
+    "body-parser": "^1.16.1",
     "express": "^4.14.0",
-    "graphql": "^0.8.2",
+    "graphql": "^0.9.1",
     "graphql-server-express": "^0.5.0",
-    "graphql-tools": "^0.9.0",
-    "whatwg-fetch": "^2.0.2"
+    "graphql-tools": "^0.10.0",
+    "isomorphic-fetch": "^2.2.1"
   }
 }

--- a/tests/client.js
+++ b/tests/client.js
@@ -1,9 +1,10 @@
 import { assert } from 'meteor/practicalmeteor:chai';
-
 import { createMeteorNetworkInterface } from 'meteor/apollo';
+
+import ApolloClient from 'apollo-client';
 import gql from 'graphql-tag';
 import { print } from 'graphql-tag/printer';
-import 'whatwg-fetch';
+import 'isomorphic-fetch';
 
 // Some helper queries + results
 const authorQuery = gql`
@@ -37,6 +38,9 @@ const personResult = {
     },
   },
 };
+
+// Authenticate the test user
+Meteor._localStorage.setItem('Meteor.loginToken', 'foobar123');
 
 describe('Network interface', function() {
   
@@ -100,5 +104,86 @@ describe('Batching network interface', function() {
     });
   });
 
+});
+
+describe('User Accounts', function() {
+  
+  // create a test util to compare a test login token to the one stored in local storage
+  const TestLoginToken = () => {
+    // default test login token value
+    let token = null;
+    
+    return {
+      // returns the value of the test login token
+      get: () => token,
+      // returns a middleware setting the test login token
+      middleware: {
+        applyMiddleware: (request, next) => {
+          if (request.options.headers) {
+            // grab the login token from the request and assign it to the test token
+            token = request.options.headers.Authorization;
+          }
+          next();
+        },
+      },
+    };
+  };
+  
+  it('should use Meteor Accounts if the option is set', async (done) => {
+    try {
+      // create a network interface using Meteor Accounts middleware
+      const networkInterface = createMeteorNetworkInterface({ useMeteorAccounts: true });
+      
+      // create a test login token and assign its test middleware to the network interface
+      const testLoginToken = new TestLoginToken();
+      networkInterface.use([testLoginToken.middleware]);
+      
+      // run a test query
+      const client = new ApolloClient({ networkInterface });
+      await client.query({query: authorQuery })
+      
+      // the login token sent with the request should be equal to the one in local storage
+      assert.equal(testLoginToken.get(), Meteor._localStorage.getItem('Meteor.loginToken'));
+      done();
+    } catch(error) {
+      done(error);
+    }
+  });
+  
+  it('should not use Meteor Accounts if the option is unset', async (done) => {
+    try {
+      // create a network interface NOT using Meteor Accounts middleware
+      const networkInterface = createMeteorNetworkInterface({ useMeteorAccounts: false });
+      
+      // create a test login token and assign its test middleware to the network interface
+      const testLoginToken = new TestLoginToken();
+      networkInterface.use([testLoginToken.middleware]);
+      
+      // run a test query
+      const client = new ApolloClient({ networkInterface });
+      await client.query({query: authorQuery })
+      
+      // there shouldn't be any login token sent with the request
+      assert.isNull(testLoginToken.get());      
+      done();
+    } catch(error) {
+      done(error);
+    }
+  });
+  
+  it('should not use Meteor Accounts middleware when a login token is set directly from the client', () => {
+    // a note adressed to someone who runs tests and looks at the client-side console
+    console.log('Note: the error shown in the console below comes from the test "should not use Meteor Accounts middleware when a login token is set directly from the client".');
+    
+    // create an "invalid" network interface
+    const networkInterface = createMeteorNetworkInterface({
+      useMeteorAccounts: true,
+      loginToken: 'xyz',
+    });
+    
+    // there shouldn't be any middleware (i.e. not the Meteor Accounts middleware) attached
+    assert.lengthOf(networkInterface._middlewares, 0);
+  });
+  
 });
   

--- a/tests/client.js
+++ b/tests/client.js
@@ -121,7 +121,7 @@ describe('User Accounts', function() {
         applyMiddleware: (request, next) => {
           if (request.options.headers) {
             // grab the login token from the request and assign it to the test token
-            token = request.options.headers.Authorization;
+            token = request.options.headers['meteor-login-token'];
           }
           next();
         },

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,39 +1,68 @@
+import { Meteor } from 'meteor/meteor';
 import { assert } from 'meteor/practicalmeteor:chai';
 import { HTTP } from 'meteor/http';
-import { createApolloServer } from 'meteor/apollo';
+import { createApolloServer, createMeteorNetworkInterface, meteorClientConfig } from 'meteor/apollo';
+import { Accounts } from 'meteor/accounts-base';
 
 import { makeExecutableSchema } from 'graphql-tools';
+import { ApolloClient } from 'apollo-client';
+import gql from 'graphql-tag';
+import 'isomorphic-fetch';
 
-describe('Graphql Server', function() {
+// Insert/update a test user with a fresh login token
+Meteor.users.upsert(
+  { username: 'test' },
+  {
+    username: 'test',
+    services: {
+      resume: {
+  			loginTokens: [
+  				{
+  					when: new Date(),
+  					hashedToken: Accounts._hashLoginToken('foobar123'),
+  				},
+        ],
+      },
+    },
+  },
+);
   
-  // create schema
-  const typeDefs = [`
-    type Query {
-      test(who: String): String
-      author: Author
-      person: Person
-    }
+// Create schema & resolvers used in the tests
+const typeDefs = [`
+  type Query {
+    test(who: String): String
+    author: Author
+    person: Person
+    currentUser: User
+  }
     
-    type Author {
-      firstName: String
-      lastName: String
-    }
-    
-    type Person {
-      name: String
-    }
-  `];
+  type Author {
+    firstName: String
+    lastName: String
+  }
+  
+  type Person {
+    name: String
+  }
+  
+  type User {
+    _id: String
+    username: String
+  }
+`];
   
   const resolvers = {
     Query: {
       test: (root, { who }) => `Hello ${who}`, 
       author: __ => ({firstName: 'John', lastName: 'Smith'}),
       person: __ => ({name: 'John Smith'}),
+      currentUser: (root, args, context) => context.user,
     } 
   };
   
   const schema = makeExecutableSchema({ typeDefs, resolvers, });
-  
+
+describe('GraphQL Server', () => {  
   it('should create an express graphql server accepting a test query', async function() {
     
     // instantiate the apollo server
@@ -44,13 +73,56 @@ describe('Graphql Server', function() {
       data: { query: '{ test(who: "World") }' }
     });
     
-    expect(queryResult).to.deep.equal({
+    assert.deepEqual(queryResult, {
       data: {
         test: 'Hello World'
       }
     });
     
   });
-  
 });
+
+describe('User Accounts', () => {
+  it('should use Meteor Accounts middleware when a login token is set server-side', () => {
+    const networkInterface = createMeteorNetworkInterface({
+      useMeteorAccounts: true,
+      loginToken: 'xyz',
+    });
+    
+    assert.lengthOf(networkInterface._middlewares, 1);
+  });
   
+  it('should return the current user when passing the right login token to the network interface server-side', async () => {
+    // instantiate the apollo server
+    const apolloServer = createApolloServer({ schema, });
+    
+    const networkInterface = createMeteorNetworkInterface({
+      useMeteorAccounts: true,
+      loginToken: 'foobar123',
+    });
+    
+    const client = new ApolloClient(meteorClientConfig({ networkInterface }));
+    
+    // send a query to the server
+    const { data: { currentUser } } = await client.query({ query: gql`{ currentUser { username } }` });
+    
+    assert.propertyVal(currentUser, 'username', 'test');
+  });
+  
+  it('should not return the current user when passing an invalid login token to the network interface server-side', async () => {
+    // instantiate the apollo server
+    const apolloServer = createApolloServer({ schema, });
+    
+    const networkInterface = createMeteorNetworkInterface({
+      useMeteorAccounts: true,
+      loginToken: 'xyz',
+    });
+    
+    const client = new ApolloClient(meteorClientConfig({ networkInterface }));
+    
+    // send a query to the server
+    const { data: { currentUser } } = await client.query({ query: gql`{ currentUser { username } }` });
+    
+    assert.isNull(currentUser);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,13 +67,13 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
-body-parser@^1.15.2:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.16.0.tgz#924a5e472c6229fb9d69b85a20d5f2532dec788b"
+body-parser@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.16.1.tgz#51540d045adfa7a0c6995a014bb6b1ed9b802329"
   dependencies:
     bytes "2.4.0"
     content-type "~1.0.2"
-    debug "2.6.0"
+    debug "2.6.1"
     depd "~1.1.0"
     http-errors "~1.5.1"
     iconv-lite "0.4.15"
@@ -102,9 +102,9 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
-debug@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+debug@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
     ms "0.7.2"
 
@@ -133,6 +133,12 @@ ee-first@1.1.1:
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
 
 es6-shim@^0.35.3:
   version "0.35.3"
@@ -221,7 +227,7 @@ graphql-server-module-graphiql@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/graphql-server-module-graphiql/-/graphql-server-module-graphiql-0.5.2.tgz#7e2a0c78b0267e784f8483ce5633810baf558dee"
 
-graphql-tag@^1.1.1:
+graphql-tag@^1.1.1, graphql-tag@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-1.2.4.tgz#90c59bea41378513fd7213dc92537fcd20e4570f"
 
@@ -249,7 +255,7 @@ http-errors@~1.5.1:
     setprototypeof "1.0.2"
     statuses ">= 1.3.1 < 2"
 
-iconv-lite@0.4.15:
+iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -260,6 +266,17 @@ inherits@2.0.3:
 ipaddr.js@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.2.0.tgz#8aba49c9192799585bdd643e0ccb50e8ae777ba4"
+
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+isomorphic-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 iterall@1.0.2:
   version "1.0.2"
@@ -320,6 +337,13 @@ ms@0.7.2:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+node-fetch@^1.0.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -433,6 +457,6 @@ vary@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.0.tgz#e1e5affbbd16ae768dd2674394b9ad3022653140"
 
-whatwg-fetch@^2.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz#fe294d1d89e36c5be8b3195057f2e4bc74fc980e"


### PR DESCRIPTION
**Rewrite of how we send the login token with the request:** https://github.com/apollographql/meteor-integration/commit/691da3f15889bc510ca51cb036f3b2b7251cef27

I felt like it was kind of messy how we handled the current user token, and as @lorensr asked when it was implemented:

> when would someone be passing a cookie to createMeteorNetworkInterface on the client?

➡️ let's just not allow it, doing something like this is hacky and leads to confusion imo.

**Tests to validate that & more:** https://github.com/apollographql/meteor-integration/commit/5132cb7f9ebf247f74fc6dc9733be0c32e4a0d12

This PR also adds several tests client & server sides 🆗 

When running the tests, a user is created with a `test` username and a `foobar123` login token. This helps to validate that the user accounts options & middleware are running correctly 😌

By the way, I've replaced `whatwg-fetch` by `isomorphic-fetch` (= `whatwg-fetch` + `node-fetch`) and added it as a dependency of the package. 

It gives access server-side & in all browsers to `fetch` & related API (`Headers`). I believe this addition will also fix this issue https://github.com/apollographql/meteor-integration/issues/73