### PR TITLE
Important fixes + removal of subscriptions (to be moved to another package)

### DIFF
--- a/.versions
+++ b/.versions
@@ -1,6 +1,6 @@
 accounts-base@1.2.15
 allow-deny@1.0.5
-apollo@0.6.1
+apollo@0.7.0
 autoupdate@1.3.12
 babel-compiler@6.14.1
 babel-runtime@1.0.1
@@ -30,7 +30,7 @@ htmljs@1.0.10
 http@1.2.12
 id-map@1.0.9
 jquery@1.11.10
-local-test:apollo@0.6.1
+local-test:apollo@0.7.0
 localstorage@1.0.12
 logging@1.1.17
 meteor@1.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 All notable changes to this project will be documented in this file. [*File syntax*](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## vNEXT
+## [0.7.0] - 2017-03-22
+### Changed
+- No more `dataIdFromObject` pre-configuration: `apollo-client` does it for us.
+- Fix accounts client-side: the login token is handled per request and not per client, by looking for it directly in the middleware.
+- Fix options server-side (issue [#90](https://github.com/apollographql/core-docs/issues/90)).
+
+# Removed
+- Breaking: Subscriptions configuration are not any more handled in this package: this package is intended to *provide easy configuration of an Apollo client and its network interface to communicate with a GraphQL Express Server*. A new package is going to be created to configure GraphQL subscriptions in a Meteor context.
 
 ## [0.6.1] - 2017-03-18
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use the [Apollo GraphQL](http://dev.apollodata.com/) client and server in your [
 
 ```sh
 meteor add apollo
-meteor npm install --save apollo-client graphql-server-express express graphql graphql-tools body-parser subscriptions-transport-ws graphql-subscriptions
+meteor npm install --save apollo-client graphql-server-express express graphql graphql-tools body-parser
 ```
 
 Read **[the docs](http://dev.apollodata.com/core/meteor.html)**

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
     "express": "^4.14.0",
     "graphql": "^0.9.1",
     "graphql-server-express": "^0.6.0",
-    "graphql-subscriptions": "^0.3.1",
-    "graphql-tools": "^0.10.0",
-    "subscriptions-transport-ws": "^0.5.5-alpha.0"
+    "graphql-tools": "^0.10.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/check-npm.js
+++ b/src/check-npm.js
@@ -4,7 +4,7 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 if (Meteor.isClient) {
   checkNpmVersions(
     {
-      'apollo-client': '^1.0.0-rc.3',
+      'apollo-client': '^1.0.0-rc.6',
     },
     'apollo'
   );
@@ -15,9 +15,7 @@ if (Meteor.isClient) {
       'body-parser': '^1.15.2',
       express: '^4.14.0',
       graphql: '^0.9.0',
-      'graphql-subscriptions': '^0.3.1',
       'graphql-tools': '^0.10.0',
-      'subscriptions-transport-ws': '^0.5.5-alpha.0',
     },
     'apollo'
   );

--- a/src/main-client.js
+++ b/src/main-client.js
@@ -129,16 +129,6 @@ export const createMeteorNetworkInterface = (customNetworkInterfaceConfig = {}) 
 const defaultClientConfig = {
   // setup ssr mode if the client is configured server-side (ex: for SSR)
   ssrMode: Meteor.isServer,
-  // leverage store normalization
-  dataIdFromObject: result => {
-    // store normalization with 'typename + Meteor's Mongo _id' if possible
-    if (result._id && result.__typename) {
-      const dataId = result.__typename + result._id;
-      return dataId;
-    }
-    // no store normalization
-    return null;
-  },
 };
 
 // create a new client config object based on the default Apollo Client config

--- a/src/main-client.js
+++ b/src/main-client.js
@@ -1,5 +1,4 @@
 import { createNetworkInterface, createBatchingNetworkInterface } from 'apollo-client';
-import { SubscriptionClient, addGraphQLSubscriptions } from 'subscriptions-transport-ws';
 
 import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
@@ -20,11 +19,6 @@ const defaultNetworkInterfaceConfig = {
   batchingInterface: true,
   // default batch interval
   batchInterval: 10,
-  // enable enhanced apollo network interface with a websocket client
-  enableSubscriptions: false,
-  // get a ws:// url from the ROOT_URL
-  // ex: ws://locahost:3000/subscriptions
-  websocketUri: Meteor.absoluteUrl('subscriptions').replace(/^http/, 'ws'),
 };
 
 // create a pre-configured network interface
@@ -100,29 +94,7 @@ export const createMeteorNetworkInterface = (customNetworkInterfaceConfig = {}) 
     }
   }
 
-  // return a configured network interface meant to be used by Apollo Client
-  // with or without subscriptions, depending on enableSubscriptions param
-  if (config.enableSubscriptions) {
-    // pass the login
-    const connectionParams = config.useMeteorAccounts
-      ? { meteorLoginToken: getMeteorLoginToken(config) }
-      : {};
-
-    // create a websocket client
-    const wsClient = new SubscriptionClient(config.websocketUri, {
-      reconnect: true,
-      connectionParams,
-    });
-
-    // plug the graphql subscriptions
-    const networkInterfaceWithSubscriptions = addGraphQLSubscriptions(networkInterface, wsClient);
-
-    // return an enhanced interface with subscriptions
-    return networkInterfaceWithSubscriptions;
-  } else {
-    // return an interface without subscriptions
-    return networkInterface;
-  }
+  return networkInterface;
 };
 
 // default Apollo Client configuration object

--- a/src/main-server.js
+++ b/src/main-server.js
@@ -69,24 +69,24 @@ export const createApolloServer = (customOptions = {}, customConfig = {}) => {
   // enhance the GraphQL server with possible express middlewares
   config.configServer(graphQLServer);
 
-  // graphqlExpress can accept a function returning the option object
-  const customOptionsObject = typeof customOptions === 'function'
-    ? customOptions(req)
-    : customOptions;
-
-  // create a new apollo options object based on the default apollo options
-  // defined above and the custom apollo options passed to this function
-  const options = {
-    ...defaultGraphQLOptions,
-    ...customOptionsObject,
-  };
-
   // GraphQL endpoint, enhanced with JSON body parser
   graphQLServer.use(
     config.path,
     bodyParser.json(),
     graphqlExpress(async req => {
       try {
+        // graphqlExpress can accept a function returning the option object
+        const customOptionsObject = typeof customOptions === 'function'
+          ? customOptions(req)
+          : customOptions;
+
+        // create a new apollo options object based on the default apollo options
+        // defined above and the custom apollo options passed to this function
+        const options = {
+          ...defaultGraphQLOptions,
+          ...customOptionsObject,
+        };
+
         // get the login token from the headers request, given by the Meteor's
         // network interface middleware if enabled
         const loginToken = req.headers['meteor-login-token'];

--- a/src/main-server.js
+++ b/src/main-server.js
@@ -128,7 +128,7 @@ export const createApolloServer = (customOptions = {}, customConfig = {}) => {
 
 // take the existing context and return a new extended context with the current
 // user if relevant (i.e. valid login token)
-const addCurrentUserToContext = async (context, loginToken) => {
+export const addCurrentUserToContext = async (context, loginToken) => {
   // there is a possible current user connected!
   if (loginToken) {
     // throw an error if the token is not a string

--- a/src/main-server.js
+++ b/src/main-server.js
@@ -1,8 +1,6 @@
 import { graphqlExpress, graphiqlExpress } from 'graphql-server-express';
 import bodyParser from 'body-parser';
 import express from 'express';
-import { SubscriptionManager } from 'graphql-subscriptions';
-import { SubscriptionServer } from 'subscriptions-transport-ws';
 
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
@@ -29,9 +27,6 @@ const defaultServerConfig = {
   graphiqlOptions: {
     passHeader: "'meteor-login-token': localStorage['Meteor.loginToken']",
   },
-  subscriptionsPath: '/subscriptions',
-  subscriptionSetupFunctions: {},
-  subscriptionLifecycle: {},
 };
 
 // default graphql options to enhance the graphQLExpress server
@@ -129,41 +124,6 @@ export const createApolloServer = (customOptions = {}, customConfig = {}) => {
 
   // this binds the specified paths to the Express server running Apollo + GraphiQL
   WebApp.connectHandlers.use(graphQLServer);
-
-  // a data publication mechanism is set up, add subscription manager & server!
-  if (options.pubsub) {
-    // create the subscription manager thanks to the schema & pubsub options
-    const subscriptionManager = new SubscriptionManager({
-      schema: options.schema,
-      pubsub: options.pubsub,
-      // eventual publication filtering
-      setupFunctions: config.subscriptionSetupFunctions,
-    });
-
-    // start up a subscription server
-    new SubscriptionServer(
-      {
-        subscriptionManager,
-        // on connect subscription lifecycle event
-        onConnect: async (connectionParams, webSocket) => {
-          // if a meteor login token is passed to the connection params from
-          // the client, add the current user to the subscription context
-          const subscriptionContext = connectionParams.meteorLoginToken
-            ? await addCurrentUserToContext(options.context, connectionParams.meteorLoginToken)
-            : options.context;
-
-          return subscriptionContext;
-        },
-        // additional subscriptions lifecycle
-        ...config.subscriptionLifecycle,
-      },
-      {
-        // bind the subscription server to Meteor WebApp
-        server: WebApp.httpServer,
-        path: config.subscriptionsPath,
-      }
-    );
-  }
 };
 
 // take the existing context and return a new extended context with the current

--- a/tests/client.js
+++ b/tests/client.js
@@ -5,8 +5,6 @@ import ApolloClient from 'apollo-client';
 import gql from 'graphql-tag';
 import { print } from 'graphql';
 
-// TODO: fix tests for subscriptions
-
 // Some helper queries + results
 const authorQuery = gql`
   query {
@@ -162,37 +160,6 @@ describe('Batching network interface', function() {
     }
   );
 });
-
-// describe('Network interface with subscriptions', () => {
-//   it('creates a network interface with a SubscriptionClient', done => {
-//     const networkInterfaceWithSubscriptions = createMeteorNetworkInterface({
-//       enableSubscriptions: true,
-//     });
-//
-//     const client = new ApolloClient(
-//       meteorClientConfig({
-//         networkInterface: networkInterfaceWithSubscriptions,
-//       })
-//     );
-//
-//     const options = {
-//       query: gql`
-//         subscription test($who: String) {
-//           test(who: $who)
-//         }
-//       `,
-//       variables: { who: 'you!' },
-//     };
-//
-//     const sub = client.subscribe(options).subscribe({
-//       next(result) {
-//         assert.deepEqual(result, 'hello you!');
-//
-//         done();
-//       },
-//     });
-//   });
-// });
 
 describe('User Accounts', function() {
   // create a test util to compare a test login token to the one stored in local storage

--- a/tests/server.js
+++ b/tests/server.js
@@ -114,6 +114,25 @@ describe('GraphQL Server', () => {
       });
     })
   );
+
+  it(
+    'should work when passing options as a function',
+    handleDone(async () => {
+      // instantiate the apollo server with options as a function
+      const apolloServer = createApolloServer(req => ({ schema }));
+
+      // send a query to the server
+      const { data: queryResult } = await HTTP.post(Meteor.absoluteUrl('/graphql'), {
+        data: { query: '{ test(who: "World") }' },
+      });
+
+      assert.deepEqual(queryResult, {
+        data: {
+          test: 'Hello World',
+        },
+      });
+    })
+  );
 });
 
 describe('User Accounts', () => {

--- a/tests/server.js
+++ b/tests/server.js
@@ -12,10 +12,7 @@ import { Accounts } from 'meteor/accounts-base';
 import { makeExecutableSchema } from 'graphql-tools';
 import { ApolloClient } from 'apollo-client';
 import gql from 'graphql-tag';
-import { PubSub } from 'graphql-subscriptions';
 import 'isomorphic-fetch';
-
-// TODO: fix tests for subscriptions
 
 // note: we are using several times `createApolloServer` in this file. It feels
 // like the `/graphql` endpoint gets overwritten each time. Is there a way to
@@ -49,10 +46,6 @@ const typeDefs = [
     randomString: String
     currentUser: User
   }
-  
-  # type Subscription {
-  #   test(who: String): String
-  # }
     
   type Author {
     firstName: String
@@ -78,9 +71,6 @@ const resolvers = {
     randomString: __ => Random.id(),
     currentUser: (root, args, context) => context.user,
   },
-  // Subscription: {
-  //   test: (root, { who }) => `Hello ${who}`,
-  // }
 };
 
 const schema = makeExecutableSchema({ typeDefs, resolvers });
@@ -189,20 +179,3 @@ describe('User Accounts', () => {
     })
   );
 });
-
-// describe('GraphQL Server with subscriptions', () => {
-//   it(
-//     'should create an express graphql server with a pubsub mechanism having access to the context',
-//     handleDone(async () => {
-//       const pubsub = new PubSub();
-//
-//       // instantiate the apollo server
-//       const apolloServer = createApolloServer({
-//         schema,
-//         pubsub,
-//       });
-//
-//       // holy cow, how do you test that?
-//     })
-//   );
-// });


### PR DESCRIPTION
Context
---
Adding subscriptions to this package has been exciting proof of concept: we can provide some configuration to help dev folks using them in their Meteor app.

*However*, doing so has broken one of the main reason of this package existence: enhancing the request sent from the client to the server:
- client-side, breaking of the current user handling (at the client instance level, and not at the HTTP request level);
- server-side, breaking the possibility to have a function depending on the HTTP request to enhance the server option, to set up Optics for instance. https://github.com/apollographql/meteor-integration/issues/90

➡️ This PR intends firstly to fix these two issues.

Meteor & GraphQL Subscriptions
---
Considering recent discussions with @DxCx, @Urigo and also discussion on docs https://github.com/apollographql/core-docs/pull/260, it appears that another package providing ease of use of the GraphQL subscriptions in a Meteor context looks promising.

We are thinking of leveraging among others things like:
- https://github.com/DxCx/graphql-rxjs
- https://github.com/Urigo/meteor-rxjs
- https://github.com/davidyaha/graphql-redis-subscriptions

This PR exports now the functions used to check if a user is connected and plug a user to the context: these could be utilized in this new package 👌 

Moreover, several issues have been opened after adding subscriptions to this package: app broken because of this new dependency, even if developers don't care at all about GraphQL subscriptions and most of these folks solved the problem by adding a blackbox a Node package they never heard about (yet). https://github.com/apollographql/meteor-integration/issues/88

Conclusion
---
We shouldn't force people to install subscriptions things when using this package. Let's keep this Atmosphere package doing one thing well: configuring and enhance the communication between a client using an HTTP based interface & a GraphQL server running with express.

And, let's build another package adding GraphQL subscriptions in a Meteor context 🔥 🚀 