### PR TITLE
expose graphQLServer object

### DIFF
--- a/src/main-server.js
+++ b/src/main-server.js
@@ -126,6 +126,8 @@ export const createApolloServer = (customOptions = {}, customConfig = {}) => {
   }
   // this binds the specified paths to the Express server running Apollo + GraphiQL
   WebApp.connectHandlers.use(graphQLServer);
+     
+  return graphQLServer;
 };
 
 export const getUserForContext = async loginToken => {


### PR DESCRIPTION
I have a use case where I need to add a middleware to always be executed **after** apollo has authenticated the user. With the currently available options I can't use `configServer` to add a middleware as it is executed before apollo does its magic.

Exposing the graphQLServer object allows me to customize the express instance as I want.  