### PR TITLE
add support for passing options.context as an async function

### DIFF
--- a/src/main-server.js
+++ b/src/main-server.js
@@ -126,8 +126,6 @@ export const createApolloServer = (customOptions = {}, customConfig = {}) => {
   }
   // this binds the specified paths to the Express server running Apollo + GraphiQL
   WebApp.connectHandlers.use(graphQLServer);
-     
-  return graphQLServer;
 };
 
 export const getUserForContext = async loginToken => {

--- a/src/main-server.js
+++ b/src/main-server.js
@@ -89,7 +89,7 @@ export const createApolloServer = (customOptions = {}, customConfig = {}) => {
 
         // context can accept a function returning the context object
         const context = typeof options.context === 'function'
-          ? options.context(userContext)
+          ? await options.context(userContext)
           : { ...options.context, ...userContext };
 
         // return the configured options to be used by the graphql server


### PR DESCRIPTION
I am working in a project where, in order to overcome the Meteor's "[don't use profile](https://guide.meteor.com/accounts.html#dont-use-profile)" issue, the equivalent of the `profile` field was moved to an independent collection.

While using Apollo I miss having the ability to load this profile into context as `context.profile`. Being able to define `context` in the options as a sync function is not enough because I need to load the profile from the database, performing an async call.

This PR:
* Reverts #104. (check [explanation](https://github.com/apollographql/meteor-integration/pull/104#issuecomment-317736427))
* Add support for passing `options.context` as an async function.
* Add tests for it.