### PR TITLE
Find /graphql relative to current page rather than configured ROOT_URL

### DIFF
--- a/src/main-client.js
+++ b/src/main-client.js
@@ -7,7 +7,7 @@ import { Accounts } from 'meteor/accounts-base';
 const defaultNetworkInterfaceConfig = {
   // default graphql server endpoint: ROOT_URL/graphql
   // ex: http://locahost:3000/graphql, or https://www.my-app.com/graphql
-  uri: Meteor.absoluteUrl('graphql'),
+  uri: `${window.location.protocol}//${window.location.host}/graphql`,
   // additional fetch options like `credentials` or `headers`
   opts: {},
   // enable the Meteor User Accounts middleware to identify the user with


### PR DESCRIPTION
When accessing an app that may have different URLs (e.g. when accessing via ngrok vs direct access) it is nice to have the graphql endpoint use same hostname as the page it is on rather than the globally configured hostname in ROOT_URL.