### PR TITLE
Update to apollo client 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.versions
+++ b/.versions
@@ -1,6 +1,6 @@
 accounts-base@1.2.17
 allow-deny@1.0.5
-apollo@1.0.0
+apollo@2.0.0
 autoupdate@1.3.12
 babel-compiler@6.18.2
 babel-runtime@1.0.1
@@ -30,7 +30,7 @@ htmljs@1.0.11
 http@1.2.12
 id-map@1.0.9
 jquery@1.11.10
-local-test:apollo@1.0.0
+local-test:apollo@2.0.0
 localstorage@1.0.12
 logging@1.1.17
 meteor@1.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to this project will be documented in this file. [*File syntax*](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## vNEXT
+## [2.0.0]
+- Basic support for Apollo Client 2.0 with `createApolloClient`, and drop support for Apollo Client 1.0
 
 ## [1.0.0] - 2017-07-27
 ### BREAKING CHANGE

--- a/README.md
+++ b/README.md
@@ -1,14 +1,31 @@
-**Note: This package supports Apollo Client 1.x**
 
-**For Apollo Client 2+, use [ddp-apollo](https://github.com/Swydo/ddp-apollo) or discuss a [new version of this package](https://github.com/apollographql/meteor-integration/issues/109)**
+> **Note: This package supports Apollo Client 2.x, to use Apollo Client 1.x, check out on the version `1.0.0`**
 
-[![Build Status](https://travis-ci.org/apollographql/meteor-integration.svg?branch=master)](https://travis-ci.org/apollographql/meteor-integration)
+> A great alternative to this package is [ddp-apollo](https://github.com/Swydo/ddp-apollo)
 
-Use the [Apollo GraphQL](http://dev.apollodata.com/) client and server in your [Meteor](https://www.meteor.com/) app.
+> We are actively looking for a new maintainer: https://github.com/apollographql/meteor-integration/issues/109
+
+Create an Apollo client & an Apollo server quickly:
+
+### Client
+```js
+import { createApolloClient } from 'meteor/apollo';
+
+const client = createApolloClient();
+```
+
+### Server
+```js
+import { createApolloServer } from 'meteor/apollo';
+
+const schema = /* your schema instance */
+
+createApolloServer({ schema });
+```
 
 ```sh
 meteor add apollo
-meteor npm install --save apollo-client apollo-server-express express graphql graphql-tools body-parser
+yarn add apollo-client apollo-link apollo-link-http apollo-cache-inmemory apollo-server-express express graphql graphql-tools body-parser
 ```
 
 Read **[the docs](http://dev.apollodata.com/core/meteor.html)**

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
-> **Note: This package supports Apollo Client 2.x, to use Apollo Client 1.x, check out on the version `1.0.0`**
+> This package supports Apollo Client 2.x. To use Apollo Client 1.x, check out on the version `1.0.0`
 
 > A great alternative to this package is [ddp-apollo](https://github.com/Swydo/ddp-apollo)
 
 > We are actively looking for a new maintainer: https://github.com/apollographql/meteor-integration/issues/109
 
-Create an Apollo client & an Apollo server quickly:
+Create an Apollo client and server quickly:
 
 ### Client
 ```js

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'apollo',
-  version: '1.0.0',
+  version: '2.0.0',
   summary: ' 🚀 Add Apollo to your Meteor app',
   git: 'https://github.com/apollostack/meteor-integration',
 });

--- a/package.json
+++ b/package.json
@@ -22,12 +22,15 @@
   },
   "homepage": "https://github.com/apollostack/meteor-integration#readme",
   "dependencies": {
-    "apollo-client": "^1.9.0-1",
+    "apollo-cache-inmemory": "^1.1.4",
+    "apollo-client": "^2.0.4",
+    "apollo-link": "^1.0.7",
+    "apollo-link-http": "^1.3.2",
     "apollo-server-express": "^1.0.4",
     "body-parser": "^1.17.2",
     "express": "^4.15.3",
-    "graphql": "^0.10.5",
-    "graphql-tools": "^1.1.0"
+    "graphql": "^0.12.3",
+    "graphql-tools": "^2.14.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "lint": "eslint --quiet --ext .js .",
     "prettier": "prettier --write \"src/*.js\" \"tests/*.js\" --single-quote=true --trailing-comma=es5 --print-width=100",
-    "pretest": "npm run lint",
     "test": "meteor test-packages ./ --driver-package practicalmeteor:mocha"
   },
   "repository": {

--- a/src/main-client.js
+++ b/src/main-client.js
@@ -25,18 +25,18 @@ export const createApolloClient = ({ link, cache }) =>
 
 export const createMeteorNetworkInterface = () => {
   throw new Error(
-    'We are glad you use the Meteor Accounts integration with Apollo, however Apollo do not support anymore `createNetworkInterface`. Please update to Apollo Client 2.0 by using the new method `createApolloClient` or revert this package to version 1.0'
+    '`createMeteorNetworkInterface()` is from v1 of this package. The API has changed to `createApolloClient()`.'
   );
 };
 
 export const meteorClientConfig = () => {
   throw new Error(
-    'We are glad you use the Meteor Accounts integration with Apollo, however Apollo do not support anymore `createNetworkInterface`. Please update to Apollo Client 2.0 by using the new method `createApolloClient` or revert this package to version 1.0'
+    '`meteorClientConfig()` is from v1 of this package. The API has changed to `createApolloClient()`.'
   );
 };
 
 export const getMeteorLoginToken = () => {
   throw new Error(
-    'We are glad you use the Meteor Accounts integration with Apollo, however Apollo do not support anymore `createNetworkInterface`. Please update to Apollo Client 2.0 by using the new method `createApolloClient` or revert this package to version 1.0'
+    '`getMeteorLoginToken` is from v1 of this package. Use `createApolloClient` or `meteorAccountsLink`.'
   );
 };

--- a/src/main-client.js
+++ b/src/main-client.js
@@ -1,132 +1,42 @@
-import { createNetworkInterface, createBatchingNetworkInterface } from 'apollo-client';
-
+import { ApolloClient } from 'apollo-client';
+import { ApolloLink } from 'apollo-link';
+import { HttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
 
-// default network interface configuration object
-const defaultNetworkInterfaceConfig = {
-  // default graphql server endpoint: ROOT_URL/graphql
-  // ex: http://locahost:3000/graphql, or https://www.my-app.com/graphql
-  uri: Meteor.absoluteUrl('graphql'),
-  // additional fetch options like `credentials` or `headers`
-  opts: {},
-  // enable the Meteor User Accounts middleware to identify the user with
-  // every request thanks to their login token
-  useMeteorAccounts: true,
-  // use a BatchingNetworkInterface by default instead of a NetworkInterface
-  batchingInterface: true,
-  // default batch interval
-  batchInterval: 10,
-};
+export const meteorAccountsLink = new ApolloLink((operation, forward) => {
+  const token = Accounts._storedLoginToken();
 
-// create a pre-configured network interface
-export const createMeteorNetworkInterface = (customNetworkInterfaceConfig = {}) => {
-  // create a new config object based on the default network interface config
-  // defined above and the custom network interface config passed to this function
-  const config = {
-    ...defaultNetworkInterfaceConfig,
-    ...customNetworkInterfaceConfig,
-  };
+  operation.setContext(() => ({
+    headers: {
+      'meteor-login-token': token,
+    },
+  }));
 
-  // this will be true true if a BatchingNetworkInterface is meant to be used
-  // with a correct poll interval
-  const useBatchingInterface = config.batchingInterface && typeof config.batchInterval === 'number';
-
-  // allow the use of a batching network interface
-  const interfaceToUse = useBatchingInterface
-    ? createBatchingNetworkInterface
-    : createNetworkInterface;
-
-  // http://dev.apollodata.com/core/apollo-client-api.html#NetworkInterfaceOptions
-  const interfaceArgument = {
-    uri: config.uri,
-    opts: config.opts,
-  };
-
-  // http://dev.apollodata.com/core/network.html#BatchingExample
-  if (useBatchingInterface) {
-    interfaceArgument.batchInterval = config.batchInterval;
-  }
-
-  // configure the (batching?) network interface with the config defined above
-  const networkInterface = interfaceToUse(interfaceArgument);
-
-  // handle the creation of a Meteor User Accounts middleware
-  if (config.useMeteorAccounts) {
-    try {
-      // throw an error if someone tries to specify the login token
-      // manually from the client
-      if (Meteor.isClient && config.loginToken) {
-        throw Error(
-          '[Meteor Apollo Integration] The current user is not handled with your GraphQL operations: you are trying to pass a login token to an Apollo Client instance defined client-side. This is only allowed during server-side rendering, please check your implementation.'
-        );
-      }
-
-      // dynamic middleware function name depending on the interface used
-      const applyMiddlewareFn = useBatchingInterface ? 'applyBatchMiddleware' : 'applyMiddleware';
-
-      // add a middleware handling the current user to the network interface
-      networkInterface.use([
-        {
-          [applyMiddlewareFn](request, next) {
-            // get the login token on a per-request basis
-            const meteorLoginToken = getMeteorLoginToken(config);
-
-            // no token, meaning no user connected, just go to next possible middleware
-            if (!meteorLoginToken) {
-              next();
-            }
-
-            // create the header object if needed.
-            if (!request.options.headers) {
-              request.options.headers = {};
-            }
-
-            // add the login token to the request headers
-            request.options.headers['meteor-login-token'] = meteorLoginToken;
-
-            // go to next middleware
-            next();
-          },
-        },
-      ]);
-    } catch (error) {
-      // catch the potential error sent by if a login token is manually set client-side
-      console.error(error);
-    }
-  }
-
-  return networkInterface;
-};
-
-// default Apollo Client configuration object
-const defaultClientConfig = {
-  // setup ssr mode if the client is configured server-side (ex: for SSR)
-  ssrMode: Meteor.isServer,
-};
-
-// create a new client config object based on the default Apollo Client config
-// defined above and the client config passed to this function
-export const meteorClientConfig = (customClientConfig = {}) => ({
-  // default network interface preconfigured, the network interface key is set
-  // there to so that `createMeteorNetworkInterface` is executed only when
-  // `meteorClientConfig` is called.
-  networkInterface: createMeteorNetworkInterface(),
-  ...defaultClientConfig,
-  ...customClientConfig,
+  return forward(operation);
 });
 
-// grab the token from the storage or config to be used in the network interface creation
-export const getMeteorLoginToken = (config = {}) => {
-  // possible cookie login token created by meteorhacks:fast-render
-  // and passed to the Apollo Client during server-side rendering
-  const { loginToken = null } = config;
+export const createApolloClient = ({ link, cache }) =>
+  new ApolloClient({
+    link: link || authLink.concat(new HttpLink({ uri: Meteor.absoluteUrl('graphql') })),
+    cache: cache || new InMemoryCache(),
+  });
 
-  // Meteor accounts-base login token stored in local storage,
-  // only exists client-side as of Meteor 1.4, will exist with Meteor 1.5
-  const localStorageLoginToken = Meteor.isClient && Accounts._storedLoginToken();
+export const createMeteorNetworkInterface = () => {
+  throw new Error(
+    'We are glad you use the Meteor Accounts integration with Apollo, however Apollo do not support anymore `createNetworkInterface`. Please update to Apollo Client 2.0 by using the new method `createApolloClient` or revert this package to version 1.0'
+  );
+};
 
-  // return a meteor login token if existing
-  // ex: grabbed from local storage or passed during server-side rendering
-  return localStorageLoginToken || loginToken;
+export const meteorClientConfig = () => {
+  throw new Error(
+    'We are glad you use the Meteor Accounts integration with Apollo, however Apollo do not support anymore `createNetworkInterface`. Please update to Apollo Client 2.0 by using the new method `createApolloClient` or revert this package to version 1.0'
+  );
+};
+
+export const getMeteorLoginToken = () => {
+  throw new Error(
+    'We are glad you use the Meteor Accounts integration with Apollo, however Apollo do not support anymore `createNetworkInterface`. Please update to Apollo Client 2.0 by using the new method `createApolloClient` or revert this package to version 1.0'
+  );
 };

--- a/src/main-client.js
+++ b/src/main-client.js
@@ -17,9 +17,9 @@ export const meteorAccountsLink = new ApolloLink((operation, forward) => {
   return forward(operation);
 });
 
-export const createApolloClient = ({ link, cache }) =>
+export const createApolloClient = ({ link, cache } = {}) =>
   new ApolloClient({
-    link: link || authLink.concat(new HttpLink({ uri: Meteor.absoluteUrl('graphql') })),
+    link: link || meteorAccountsLink.concat(new HttpLink({ uri: Meteor.absoluteUrl('graphql') })),
     cache: cache || new InMemoryCache(),
   });
 

--- a/src/main-server.js
+++ b/src/main-server.js
@@ -7,10 +7,6 @@ import { WebApp } from 'meteor/webapp';
 import { Accounts } from 'meteor/accounts-base';
 import { check } from 'meteor/check';
 
-// import the configuration functions from the client so they can be used
-// during server-side rendering for instance
-export { createMeteorNetworkInterface, meteorClientConfig } from './main-client';
-
 // default server configuration object
 const defaultServerConfig = {
   // graphql endpoint

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@types/async@^2.0.31":
-  version "2.0.38"
-  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.38.tgz#5c369dcb14788da0621daafa8594a053b0edcb21"
+"@types/async@2.0.45":
+  version "2.0.45"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.45.tgz#0cfe971d7ed5542695740338e0455c91078a0e83"
 
 "@types/express-serve-static-core@*":
   version "4.0.40"
@@ -23,14 +23,6 @@
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.9.1.tgz#b04ebe84bc997cc60dbea2ed4d0d4342c737f99d"
 
-"@types/graphql@^0.9.4":
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.9.4.tgz#cdeb6bcbef9b6c584374b81aa7f48ecf3da404fa"
-
-"@types/isomorphic-fetch@0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz#3c3483e606c041378438e951464f00e4e60706d6"
-
 "@types/mime@*":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-0.0.29.tgz#fbcfd330573b912ef59eeee14602bface630754b"
@@ -46,9 +38,9 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@types/zen-observable@^0.5.1":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.2.tgz#d84e54a0e16d2b4404e0795ae493a39a3902bdd8"
+"@types/zen-observable@0.5.3", "@types/zen-observable@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
 
 abbrev@1:
   version "1.1.0"
@@ -124,39 +116,53 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
-apollo-client@^1.9.0-1:
-  version "1.9.0-1"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-1.9.0-1.tgz#4f5dccb95e0413b884af91b68552618be8a7411c"
+apollo-cache-inmemory@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.4.tgz#63485b18f56f9ceb912df235b42959e890c89747"
   dependencies:
-    apollo-link "^0.0.3"
-    graphql "^0.10.0"
-    graphql-anywhere "^3.0.1"
-    graphql-tag "^2.0.0"
-    redux "^3.4.0"
+    apollo-cache "^1.0.2"
+    apollo-utilities "^1.0.3"
+    graphql-anywhere "^4.0.1"
+
+apollo-cache@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.0.2.tgz#e3df98696c648649d16a6c3ca9c19e90a556effa"
+  dependencies:
+    apollo-utilities "^1.0.3"
+
+apollo-client@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.0.4.tgz#425c2944e068602b4e002b3f1ad08ddd893f1a0c"
+  dependencies:
+    "@types/zen-observable" "^0.5.3"
+    apollo-cache "^1.0.2"
+    apollo-link "^1.0.0"
+    apollo-link-dedup "^1.0.0"
+    apollo-utilities "^1.0.3"
     symbol-observable "^1.0.2"
-    whatwg-fetch "^2.0.0"
+    zen-observable "^0.6.0"
   optionalDependencies:
-    "@types/async" "^2.0.31"
-    "@types/graphql" "^0.9.0"
-    "@types/isomorphic-fetch" "0.0.34"
+    "@types/async" "2.0.45"
 
-apollo-fetch@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/apollo-fetch/-/apollo-fetch-0.3.0.tgz#30a88346252e9bb4b969f93f3b23ecd748f84e68"
+apollo-link-dedup@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.5.tgz#1c213d7ebbe48e74b016fffacd7e6a53dc309e32"
   dependencies:
-    isomorphic-fetch "^2.2.1"
+    apollo-link "^1.0.7"
 
-apollo-link@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-0.0.3.tgz#9b02db8def792688e14f8be8b30f716f7789acb9"
+apollo-link-http@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.3.2.tgz#63537ee5ecf9c004efb0317f1222b7dbc6f21559"
   dependencies:
-    apollo-fetch "^0.3.0"
-    graphql "^0.10.3"
-    graphql-tag "^2.4.2"
-    zen-observable "git+https://github.com/evanshauser/zen-observable.git"
-  optionalDependencies:
-    "@types/graphql" "^0.9.4"
-    "@types/zen-observable" "^0.5.1"
+    apollo-link "^1.0.7"
+
+apollo-link@^1.0.0, apollo-link@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.0.7.tgz#42cd38a7378332fc3e41a214ff6a6e5e703a556f"
+  dependencies:
+    "@types/zen-observable" "0.5.3"
+    apollo-utilities "^1.0.0"
+    zen-observable "^0.6.0"
 
 apollo-server-core@^1.0.2:
   version "1.0.2"
@@ -177,6 +183,10 @@ apollo-server-express@^1.0.4:
 apollo-server-module-graphiql@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/apollo-server-module-graphiql/-/apollo-server-module-graphiql-1.0.4.tgz#d6db21a8c60f052649124da5cde1d88dab702319"
+
+apollo-utilities@^1.0.0, apollo-utilities@^1.0.1, apollo-utilities@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.3.tgz#bf435277609850dd442cf1d5c2e8bc6655eaa943"
 
 aproba@^1.0.3:
   version "1.1.1"
@@ -1377,33 +1387,25 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-anywhere@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-3.0.1.tgz#73531db861174c8f212eafb9f8e84944b38b4e5a"
-
-graphql-tag@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.2.0.tgz#9ea24f35a19aab1be1e55675928344d84d852905"
-
-graphql-tag@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.4.2.tgz#6a63297d8522d03a2b72d26f1b239aab343840cd"
-
-graphql-tools@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-1.1.0.tgz#8d86ea6997b0dea3089b62dc655e47146a663ebb"
+graphql-anywhere@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.0.tgz#87c12f488e7c4c357f0045cb5208a35d12171d36"
   dependencies:
+    apollo-utilities "^1.0.3"
+
+graphql-tools@^2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-2.14.1.tgz#15f96683d7f178042baddcfc17d73dcfeee67356"
+  dependencies:
+    apollo-utilities "^1.0.1"
     deprecated-decorator "^0.1.6"
-    lodash "^4.3.0"
-    uuid "^3.0.1"
-  optionalDependencies:
-    "@types/graphql" "^0.9.0"
+    uuid "^3.1.0"
 
-graphql@^0.10.0, graphql@^0.10.3, graphql@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
+graphql@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
   dependencies:
-    iterall "^1.1.0"
+    iterall "1.1.3"
 
 har-validator@~2.0.6:
   version "2.0.6"
@@ -1698,9 +1700,9 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-iterall@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 jest-docblock@^20.0.1:
   version "20.0.3"
@@ -1818,10 +1820,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.2.1:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
-
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -1834,7 +1832,7 @@ lodash.memoize@4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1842,7 +1840,7 @@ loglevel@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.1.0.tgz#82c94f9b73774b4a1cd2e4ae6562b3a8b676df4b"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2349,15 +2347,6 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-redux@^3.4.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
-  dependencies:
-    lodash "^4.2.1"
-    lodash-es "^4.2.1"
-    loose-envify "^1.1.0"
-    symbol-observable "^1.0.2"
-
 regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
@@ -2802,9 +2791,13 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@^3.0.0, uuid@^3.0.1:
+uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+
+uuid@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 v8flags@^2.0.10:
   version "2.0.11"
@@ -2829,7 +2822,7 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.0:
+whatwg-fetch@>=0.10.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz#fe294d1d89e36c5be8b3195057f2e4bc74fc980e"
 
@@ -2873,6 +2866,6 @@ yauzl@2.4.1:
   dependencies:
     fd-slicer "~1.0.1"
 
-"zen-observable@git+https://github.com/evanshauser/zen-observable.git":
-  version "0.5.2"
-  resolved "git+https://github.com/evanshauser/zen-observable.git#a11ee4bd848f381898b6cd93c769eb1dcc0febf6"
+zen-observable@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.6.1.tgz#01dbed3bc8d02cbe9ee1112c83e04c807f647244"


### PR DESCRIPTION
Fixes #109 

I took the code [from this comment](https://github.com/apollographql/meteor-integration/issues/109#issuecomment-337906848), while deprecating code from Apollo Client 1.0 (not exported by Apollo Client anymore).

So the integration client side looks [like this](https://github.com/apollographql/meteor-integration/blob/6700dd2d74f66ecfa740a228960c2a3b035909a3/src/main-client.js).

Thanks @lorensr for the message in the readme! 🎩 

I'm no longer able to invest time in maintaining this package, in consideration of your work on `ddp-apollo` and your investment in the community, @jamiter would you like to help Loren maintain this package and make it go forward for a bright future? 🚀 