### PR TITLE
Do not set header when token is falsy

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -6,12 +6,14 @@ const DEFAULT_HEADER = 'authorization'
 export const MeteorAccountsLink = ({ headerName = DEFAULT_HEADER } = {}) =>
   new ApolloLink((operation, forward) => {
     const token = Accounts._storedLoginToken()
-
-    operation.setContext(() => ({
-      headers: {
-        [headerName]: token
-      }
-    }))
-
+    
+    if (token){
+      operation.setContext(() => ({
+        headers: {
+          [headerName]: token
+        }
+      }))
+    }
+    
     return forward(operation)
   })


### PR DESCRIPTION
See #130. It makes the "authorization" header more consistent (legacy code, use with another server etc.) by not sending `"null"` or `"undefined"` strings.